### PR TITLE
Install prettier by default to cs-fix apex

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:stretch-slim
 
-RUN apt update && apt install -y git openssh-server ca-certificates openssl jq gettext xmlstarlet build-essential
+RUN apt update && apt install -y git openssh-server ca-certificates openssl jq gettext xmlstarlet build-essential openjdk-8-jdk-headless
 
-RUN npm install sfdx-cli --global
+RUN npm install sfdx-cli prettier prettier-plugin-apex --global
 RUN sfdx --version
 RUN sfdx plugins --core
 


### PR DESCRIPTION
It's handy to have [prettier](https://prettier.io/) available on command line to check code standard and auto fix it.